### PR TITLE
fix setting video stream

### DIFF
--- a/fluid-webcam-with-mouse-interaction.html
+++ b/fluid-webcam-with-mouse-interaction.html
@@ -243,11 +243,7 @@
           video: {width: 1280, height: 720, facingMode: 'user'}
         };
         navigator.mediaDevices.getUserMedia(constraints).then((stream) => {
-          if (video.srcObject) {
-            video.srcObject = stream;
-          } else {
-            video.src = window.URL.createObjectURL(stream);
-          }
+          video.srcObject = stream;
           video.play();
         }).catch((error) => {
           console.error('can not access webcam.', error);


### PR DESCRIPTION
I fixed the error
```
fluid-webcam-with-mouse-interaction.html:253 can not access webcam. TypeError: Failed to execute 'createObjectURL' on 'URL': Overload resolution failed.
    at fluid-webcam-with-mouse-interaction.html:249:36
```
demo
https://code4fukui.github.io/study-three.js/fluid-webcam-with-mouse-interaction.html

Thank you for your great repo!